### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   - XDEBUG_MODE=coverage
 
 php:
-  - 7.3
   - 7.4
   - 8.0
 

--- a/composer.json
+++ b/composer.json
@@ -8,29 +8,29 @@
         "laminas-api-tools"
     ],
     "require": {
-        "php": "^7.3|~8.0",
+        "php": "^7.4 | ~8.0",
         "laminas-api-tools/api-tools-oauth2": "^1.4",
         "doctrine/orm": "^2.5.11",
-        "doctrine/doctrine-module": "^1.2 || ^2.1 || ^3.0 || ^4.0",
-        "doctrine/doctrine-orm-module": "^1.1.5 || ^2.1 || ^3.0",
+        "doctrine/doctrine-module": "^4.0 || ^5.0",
+        "doctrine/doctrine-orm-module": "^4.0 || ^5.0",
         "laminas-api-tools/api-tools-mvc-auth": "^1.4.3",
         "laminas/laminas-mvc": "^3.0",
-        "laminas/laminas-config": "^2.6 || ^3.0",
+        "laminas/laminas-config": "^3.0",
         "laminas/laminas-modulemanager": "^2.0",
         "laminas/laminas-servicemanager": "^3.0",
         "laminas/laminas-i18n": "^2.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "laminas/laminas-form": "^2.10",
+        "laminas/laminas-form": "^3.1",
         "laminas/laminas-loader": "^2.4",
         "laminas/laminas-log": "^2.9",
         "laminas/laminas-serializer": "^2.7",
-        "laminas/laminas-test": "^3.1",
+        "laminas/laminas-test": "^4.0",
         "laminas/laminas-authentication": "^2.5",
         "laminas/laminas-eventmanager": "^3.2",
-        "mockery/mockery": "^0.9.5",
-        "satooshi/php-coveralls": "^1.0",
+        "mockery/mockery": "^1.0",
+        "php-coveralls/php-coveralls": "^2.5",
         "api-skeletons/coding-standard": "^1.0"
     },
     "autoload": {

--- a/test/asset/orm-autoload/local.php
+++ b/test/asset/orm-autoload/local.php
@@ -20,7 +20,7 @@ return [
     'doctrine' => [
         'connection' => [
             'orm_default' => [
-                'driverClass' => 'Doctrine\DBAL\Driver\PDOSqlite\Driver',
+                'driverClass' => 'Doctrine\DBAL\Driver\PDO\SQLite\Driver',
                 'params' => [
                     'memory' => 'true',
                 ],


### PR DESCRIPTION
Hi there, I've updated the dependencies, specifically `doctrine/doctrine-orm-module` so PHP 8 can be used
Also dropped support for PHP7.3 as it is no longer maintained